### PR TITLE
refactor: 💡 remove wrap string

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+lint = "clippy -- -D warnings"

--- a/crates/recursive-parser/examples/plugin.rs
+++ b/crates/recursive-parser/examples/plugin.rs
@@ -12,7 +12,7 @@ fn main() {
     }
 }";
   let bootstrap = include_str!("../../../assets/bootstrap-reboot.css");
-  let mut start = Instant::now();
+  let start = Instant::now();
   let mut root = Parser::new(bootstrap).parse().unwrap();
   println!("parse {:?}", start.elapsed());
   // start = Instant::now();

--- a/crates/recursive-parser/examples/pretty_print_ast.rs
+++ b/crates/recursive-parser/examples/pretty_print_ast.rs
@@ -1,0 +1,12 @@
+use recursive_parser::{parser::Parser, pretty_print_ast};
+fn main() {
+  let css = "#id {                     font-size: 12px; 
+        width: 100px;
+        @media test {
+            .test { width: 100px; height: 200px;}
+        }
+    }";
+  let root = Parser::new(css).parse().unwrap();
+  let result = pretty_print_ast(&root);
+  println!("{}", result);
+}

--- a/crates/recursive-parser/src/ast_util.rs
+++ b/crates/recursive-parser/src/ast_util.rs
@@ -1,7 +1,7 @@
+use crate::parser::Root;
 use crate::{parser, visitor::Visit};
-use std::io::Result;
-use std::io::Write;
-
+use std::fmt::Result;
+use std::fmt::Write;
 #[derive(Default)]
 pub struct AstPrinter<W: Write> {
   level: usize,
@@ -13,7 +13,7 @@ impl<W: Write> AstPrinter<W> {
     Self { level, writer }
   }
 
-  pub fn print<'a>(&mut self, root: &'a parser::Root<'a>) -> Result<()> {
+  pub fn print<'a>(&mut self, root: &'a parser::Root<'a>) -> Result {
     self.visit_root(root)?;
     Ok(())
   }
@@ -23,8 +23,8 @@ impl<W: Write> AstPrinter<W> {
   }
 }
 
-impl<'a, W: Write> Visit<'a, Result<()>> for AstPrinter<W> {
-  fn visit_root(&mut self, root: &parser::Root) -> Result<()> {
+impl<'a, W: Write> Visit<'a, Result> for AstPrinter<W> {
+  fn visit_root(&mut self, root: &parser::Root) -> Result {
     writeln!(
       self.writer,
       "{}Root@{:?}",
@@ -49,7 +49,7 @@ impl<'a, W: Write> Visit<'a, Result<()>> for AstPrinter<W> {
     Ok(())
   }
 
-  fn visit_rule(&mut self, rule: &parser::Rule) -> Result<()> {
+  fn visit_rule(&mut self, rule: &parser::Rule) -> Result {
     writeln!(
       self.writer,
       "{}Rule@{:?}",
@@ -80,7 +80,7 @@ impl<'a, W: Write> Visit<'a, Result<()>> for AstPrinter<W> {
     Ok(())
   }
 
-  fn visit_at_rule(&mut self, at_rule: &parser::AtRule) -> Result<()> {
+  fn visit_at_rule(&mut self, at_rule: &parser::AtRule) -> Result {
     writeln!(
       self.writer,
       "{}AtRule@{:?}",
@@ -117,7 +117,7 @@ impl<'a, W: Write> Visit<'a, Result<()>> for AstPrinter<W> {
     Ok(())
   }
 
-  fn visit_declaration(&mut self, decl: &parser::Declaration) -> Result<()> {
+  fn visit_declaration(&mut self, decl: &parser::Declaration) -> Result {
     writeln!(
       self.writer,
       "{}Declaration@{:?}",
@@ -142,27 +142,9 @@ impl<'a, W: Write> Visit<'a, Result<()>> for AstPrinter<W> {
   }
 }
 
-#[derive(Debug, Default)]
-pub struct WrapString(pub String);
-impl WrapString {
-  pub fn inner_string(self) -> String {
-    self.0
-  }
-}
-
-impl From<String> for WrapString {
-  fn from(string: String) -> Self {
-    Self(string)
-  }
-}
-
-impl Write for WrapString {
-  fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-    self.0 += std::str::from_utf8(buf).unwrap();
-    Ok(buf.len())
-  }
-
-  fn flush(&mut self) -> std::io::Result<()> {
-    Ok(())
-  }
+pub fn pretty_print_ast(root: &Root) -> String {
+  let mut printer = AstPrinter::new(0, String::default());
+  printer.print(&root).unwrap();
+  let ast_string = printer.result();
+  ast_string
 }

--- a/crates/recursive-parser/src/ast_util.rs
+++ b/crates/recursive-parser/src/ast_util.rs
@@ -144,7 +144,6 @@ impl<'a, W: Write> Visit<'a, Result> for AstPrinter<W> {
 
 pub fn pretty_print_ast(root: &Root) -> String {
   let mut printer = AstPrinter::new(0, String::default());
-  printer.print(&root).unwrap();
-  let ast_string = printer.result();
-  ast_string
+  printer.print(root).unwrap();
+  printer.result()
 }

--- a/crates/recursive-parser/tests/basic.rs
+++ b/crates/recursive-parser/tests/basic.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 mod test_ast {
   use std::fs::read_to_string;
 
-  use recursive_parser::{parser::Parser, AstPrinter, WrapString};
+  use recursive_parser::{parser::Parser, AstPrinter};
 
   use super::*;
 
@@ -31,9 +31,9 @@ mod test_ast {
       let expected_ast = read_to_string(expected_ast_path)?;
       let parser = Parser::new(&file);
       let root = parser.parse().unwrap();
-      let mut printer = AstPrinter::new(0, WrapString::default());
+      let mut printer = AstPrinter::new(0, String::default());
       printer.print(&root)?;
-      let ast = printer.result().0;
+      let ast = printer.result();
       similar_asserts::assert_str_eq!(ast, expected_ast);
     }
 
@@ -84,9 +84,9 @@ mod test_ast {
       let expected_ast = read_to_string(expected_ast_path)?;
       let parser = Parser::new(&file);
       let root = parser.parse().unwrap();
-      let mut printer = AstPrinter::new(0, WrapString::default());
+      let mut printer = AstPrinter::new(0, String::default());
       printer.print(&root)?;
-      let ast = printer.result().0;
+      let ast = printer.result();
       similar_asserts::assert_str_eq!(ast, expected_ast);
     }
     Ok(())


### PR DESCRIPTION
1. remove wrap string, we could use `std::fmt::Write` with `String`
directly
2. Adding handy `remove-wrap-string` helper function to debug ast